### PR TITLE
fix: ensure return to parent buffer after cancelling undo-propose

### DIFF
--- a/undo-propose.el
+++ b/undo-propose.el
@@ -139,6 +139,7 @@ buffer contents are copied."
   (interactive)
   (let ((tmp-buffer (current-buffer))
         (orig-buffer undo-propose-parent))
+    (switch-to-buffer orig-buffer)
     (kill-buffer tmp-buffer)
     (message "Cancel Undo-Propose!")))
 


### PR DESCRIPTION
Minor fix. I have a feeling that the parent buffer can be set implicitly with interactive though, which might save a few lines of code.

Pertains to issue #12 