### PR TITLE
ensure return to parent buffer after squashing or committing

### DIFF
--- a/undo-propose.el
+++ b/undo-propose.el
@@ -107,6 +107,7 @@ If already inside an undo-propose buffer, this will simply call `undo'."
     (copy-to-buffer orig-buffer 1 (buffer-end 1))
     (with-current-buffer orig-buffer
       (setq-local buffer-undo-list list-copy))
+    (switch-to-buffer orig-buffer)
     (kill-buffer tmp-buffer)
     (goto-char pos)
     (set-window-start (selected-window) win-start)
@@ -130,6 +131,7 @@ buffer contents are copied."
         (goto-char (point-max))
         (insert-buffer-substring tmp-buffer first-diff tmp-end)
         (goto-char first-diff)))
+    (switch-to-buffer orig-buffer)
     (kill-buffer tmp-buffer)
     (message "undo-propose: squash commit")))
 (define-obsolete-function-alias 'undo-propose-commit-buffer-only


### PR DESCRIPTION
I should have caught this with that other PR.