### PR TITLE
Suppress flicking for org-mode

### DIFF
--- a/undo-propose.el
+++ b/undo-propose.el
@@ -66,9 +66,11 @@ If already inside an undo-propose buffer, this will simply call `undo'."
           (tmp-buffer (generate-new-buffer
                        (concat "*Undo Propose: "
                                (buffer-name) "*"))))
+      (with-current-buffer tmp-buffer
+        (funcall mode)
+        (insert-buffer-substring orig-buffer
+                                 1 (1+ (buffer-size orig-buffer))))
       (switch-to-buffer tmp-buffer nil t)
-      (funcall mode)
-      (insert-buffer-substring orig-buffer 1 (1+ (buffer-size orig-buffer)))
       (goto-char pos)
       (set-window-start (selected-window) win-start)
       (setq-local buffer-undo-list list-copy)


### PR DESCRIPTION
Hi!

I'm trying to use this nice package in org buffers with the additional settings (see below). The settings itself is not discussion item in this PR.

The original implementation will copy content in an org buffer including "PROPERTIES" and "LOGBOOK" sections. But at that time, every "PROPERTIES" and "LOGBOOK" sections is unfolded. In my settings for org mode will immediately fold back the all sections after `undo-propose`.

The combination unfold and fold will create a flicking on the visible buffer like this:

![Untitled](https://user-images.githubusercontent.com/136673/64317420-a2b02980-cff2-11e9-9c75-a3727049ef94.gif)

So I slightly modified the original implementation not to show the unfolded content in the current buffer. The modified code will insert the original content with unfolded "PROPERTIES" and "LOGBOOK" to the temporal buffer but not show them to users by using `with-current-buffer`. After that, the temporal buffer will be rendered by `switch-to-buffer` as a visible buffer. If the changes is applied to `undo-propose`, then the flicking will be suppressed like this:

![Untitled1](https://user-images.githubusercontent.com/136673/64317637-4b5e8900-cff3-11e9-8946-115920018043.gif)

The following code is an extension for supporting org mode buffers.

```elisp
(defun my-org-reveal-and-focus (&optional _arg)
  "Reveal a heading and focus on the content."
  (when (eq major-mode 'org-mode)
    (org-overview)
    (unless (org-before-first-heading-p)
      (org-reveal)
      (org-cycle-hide-drawers 'all)
      (org-show-entry)
      (show-children)
      (org-show-siblings))))

(advice-add 'undo :after #'my-org-reveal-and-focus)
(advice-add 'undo-propose-commit :after #'my-org-reveal-and-focus)
(advice-add 'undo-squash-commit :after #'my-org-reveal-and-focus)

(global-set-key (kbd "C-/") 'undo-propose)

;; Immediate undo when you call `undo-propose'. I'll create another PR for this.
(defun my-undo-propose-and-undo (f)
      "Undo even when `undo-propose' is initiated."
      (let ((status (bound-and-true-p undo-propose-mode)))
        (funcall f)
        (unless status
          (undo))))
(advice-add 'undo-propose :around #'my-undo-propose-and-undo)
```

Best,
Takaaki