### PR TITLE
Handle org-clock-marker properly

### DIFF
--- a/undo-propose.el
+++ b/undo-propose.el
@@ -169,7 +169,7 @@ buffer contents are copied."
     (switch-to-buffer orig-buffer)
     (kill-buffer tmp-buffer)
     (when org-clock-marker-pos
-      (set-marker org-clock-marker org-clock-marker-pos))
+      (move-marker org-clock-marker org-clock-marker-pos))
     (message "undo-propose: squash commit"))
   (run-hooks 'undo-propose-done-hook))
 (define-obsolete-function-alias 'undo-propose-commit-buffer-only


### PR DESCRIPTION
Hi.

This PR will support remaining `org-clock-marker` properly. The original implementation will loose the marker position of `org-clock-marker` when `copy-to-buffer` in `undo-propose-commit` and `undo-propose-squash-commit` if the original buffer has an active clock. It causes a breaking of `org-clock`.

So I added a new private and buffer local variable `undo-propose--org-clock-marker`. The workflow to keep `org-clock` is built as follow:

1. In `undo-propose` command, check the original buffer is `org` and having an active clock. 
2. If not, do nothing. It it is, then prepare a local marker and copy the position.
3. Undos probably change the position of the active clock, but the local marker can follow it.
4. In `undo-propose-commit` or `undo-propose-squash-commit`, move the position of `org-clock-marker` to the right position that is recorded in `undo-propose--org-clock-marker`.

Best,
Takaaki