### PR TITLE
Add undo-propose-marker-list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test
+test:
+	emacs -batch -l ert -l undo-propose.el -l undo-propose-test.el -f ert-run-tests-batch-and-exit

--- a/Readme.org
+++ b/Readme.org
@@ -61,6 +61,12 @@ add [[https://www.emacswiki.org/emacs/RedoMode][redo]], call ~(undo-propose-wrap
 - ~undo-propose-done-hook~ is run after committing or squash
   committing an undo-propose
 
+*** Markers
+
+Currently =undo-propose= does not correctly update markers in the
+parent buffer after undo'ing. As a workaround, you can add markers to
+=undo-propose-marker-list= to ensure they are updated after undo'ing.
+
 *** Example configurations
 **** Simple configuration
 

--- a/undo-propose-test.el
+++ b/undo-propose-test.el
@@ -1,0 +1,31 @@
+;;; undo-propose-test.el --- Tests for undo-propose
+
+(require 'undo-propose)
+
+(defmacro with-undoable-temp-buffer (&rest body)
+  "Like `with-temp-buffer', but doesn't disable `undo'."
+  `(let ((temp-buffer (generate-new-buffer
+                      ;; this must NOT start with a space, otherwise
+                      ;; undo won't work. See `get-buffer-create'
+                      "*temp*")))
+    (unwind-protect
+        (with-current-buffer temp-buffer
+          ,@body)
+      (kill-buffer temp-buffer))))
+
+(ert-deftest undo-propose-test-org-clock ()
+  (with-undoable-temp-buffer
+    (org-mode)
+    (insert "* test\n")
+    (undo-boundary)
+    (org-clock-in)
+    (undo-boundary)
+    (goto-char (point-max))
+    (insert "\nfoobar")
+    (undo-boundary)
+    (undo-propose)
+    (call-interactively (command-remapping 'undo))
+    (undo-propose-commit)
+    (org-clock-out)))
+
+;;; undo-propose-test.el ends here

--- a/undo-propose.el
+++ b/undo-propose.el
@@ -57,6 +57,8 @@
   :group 'undo-propose)
 
 (defvar undo-propose-parent nil "Parent buffer of ‘undo-propose’ buffer.")
+(defvar undo-propose--org-clock-marker nil "Backup of `org-clock-marker'.")
+(make-variable-buffer-local 'undo-propose--org-clock-marker)
 
 (defun undo-propose--message (content)
   "Message CONTENT, possibly with prefix \"undo-propose: \"."
@@ -97,6 +99,13 @@ If already inside an `undo-propose' buffer, this will simply call `undo'."
       (setq-local buffer-undo-list list-copy)
       (setq-local buffer-read-only t)
       (setq-local undo-propose-parent orig-buffer)
+      (when (and (eq major-mode 'org-mode)
+                 (org-clock-is-active)
+                 (eq undo-propose-parent
+                     (marker-buffer org-clock-marker)))
+        (setq undo-propose--org-clock-marker (make-marker))
+        (move-marker undo-propose--org-clock-marker
+                     (marker-position org-clock-marker)))
       (undo-propose-mode 1)
       (run-hooks 'undo-propose-entry-hook)
       (undo-propose--message "C-c C-c to commit, C-c C-s to squash commit, C-c C-k to cancel, C-c C-d to diff"))))
@@ -127,7 +136,14 @@ If already inside an `undo-propose' buffer, this will simply call `undo'."
         (orig-buffer undo-propose-parent)
         (list-copy (undo-copy-list buffer-undo-list))
         (pos (point))
-        (win-start (window-start)))
+        (win-start (window-start))
+        (org-clock-marker-pos
+         (when (and (eq major-mode 'org-mode)
+                    (org-clock-is-active)
+                    (eq undo-propose-parent
+                        (marker-buffer org-clock-marker))
+                    (marker-position undo-propose--org-clock-marker))
+           (marker-position undo-propose--org-clock-marker))))
     (copy-to-buffer orig-buffer 1 (buffer-end 1))
     (with-current-buffer orig-buffer
       (setq-local buffer-undo-list list-copy))
@@ -135,6 +151,8 @@ If already inside an `undo-propose' buffer, this will simply call `undo'."
     (kill-buffer tmp-buffer)
     (goto-char pos)
     (set-window-start (selected-window) win-start)
+    (when org-clock-marker-pos
+      (move-marker org-clock-marker org-clock-marker-pos))
     (undo-propose--message "commit"))
   (run-hooks 'undo-propose-done-hook))
 
@@ -148,7 +166,14 @@ buffer contents are copied."
          (orig-buffer undo-propose-parent)
          (orig-end (1+ (buffer-size orig-buffer)))
          (first-diff (abs (compare-buffer-substrings
-                           tmp-buffer 1 tmp-end orig-buffer 1 orig-end))))
+                           tmp-buffer 1 tmp-end orig-buffer 1 orig-end)))
+         (org-clock-marker-pos
+          (when (and (eq major-mode 'org-mode)
+                     (org-clock-is-active)
+                     (eq undo-propose-parent
+                         (marker-buffer org-clock-marker))
+                     (marker-position undo-propose--org-clock-marker))
+            (marker-position undo-propose--org-clock-marker))))
     ;; copy from 1st diff, so we don't jump to top of buffer when redoing
     (with-current-buffer orig-buffer
       (when (/= first-diff 0)
@@ -158,6 +183,8 @@ buffer contents are copied."
         (goto-char first-diff)))
     (switch-to-buffer orig-buffer)
     (kill-buffer tmp-buffer)
+    (when org-clock-marker-pos
+      (move-marker org-clock-marker org-clock-marker-pos))
     (undo-propose--message "squash commit"))
   (run-hooks 'undo-propose-done-hook))
 (define-obsolete-function-alias 'undo-propose-commit-buffer-only


### PR DESCRIPTION
This PR generalizes #21 and provides a workaround for #22, to correctly update markers after undo'ing. In particular, it creates a list `undo-propose-marker-list`, and undo-propose will update the positions of markers in this list after undo'ing.

In addition, it adds a unit testing framework to undo-propose and adds a test for `org-clock-marker` as the first unit test. 
