### PR TITLE
fix package-lint/check-doc/byte-compiler warnings

### DIFF
--- a/undo-propose.el
+++ b/undo-propose.el
@@ -202,6 +202,8 @@ buffer contents are copied."
   (interactive)
   (ediff-buffers undo-propose-parent (current-buffer)))
 
+(defvar-local undo-propose-marker-map nil)
+
 (defun undo-propose-copy-markers ()
   "Copy markers registered in `undo-propose-marker-list'."
   (setq-local undo-propose-marker-map


### PR DESCRIPTION
Hi!
I found this package and fix package-lint/check-doc/byte-compiler warnings for my first contribution step!

### before
```emacs-lisp
 undo-pr…   218  43 warning         assignment to free variable ‘undo-propose-marker-map’ (emacs-lisp)
 undo-pr…   222  31 warning         reference to free variable ‘undo-propose-marker-map’ (emacs-lisp)
```

### after
No issues!